### PR TITLE
fix(ci): flexible test stage execution

### DIFF
--- a/.jenkins/shared-lib/primary/vars/staging.groovy
+++ b/.jenkins/shared-lib/primary/vars/staging.groovy
@@ -27,12 +27,13 @@ ${settings.lint.command}
     return successRet
 }
 
-// assumes java. not expecting tests for frontend
 def test(Map params = [:]) {
     def path = params.path
     def settings = params.settings
 
     def name = "test / ${checksUtil.nameFromDirectory([path: path])}"
+    checksUtil.pending name: name
+
     def successRet = false
     def summary = """
 ```sh


### PR DESCRIPTION
Tests are no longer limited to supporting maven tests, allowing for frontend tests.

Closes #52
