### PR TITLE
chore: update maven test command

### DIFF
--- a/backend/card-service/.ci.json
+++ b/backend/card-service/.ci.json
@@ -6,7 +6,7 @@
     },
     "test": {
         "enabled": true,
-        "command": "mvn -B test"
+        "command": "mvn -B test -DfailIfNoTests"
     },
     "build": {
         "enabled": true,

--- a/backend/listing-service/.ci.json
+++ b/backend/listing-service/.ci.json
@@ -6,7 +6,7 @@
     },
     "test": {
         "enabled": true,
-        "command": "mvn -B test"
+        "command": "mvn -B test -DfailIfNoTests"
     },
     "build": {
         "enabled": true,

--- a/backend/trade-service/.ci.json
+++ b/backend/trade-service/.ci.json
@@ -6,7 +6,7 @@
     },
     "test": {
         "enabled": true,
-        "command": "mvn -B test"
+        "command": "mvn -B test -DfailIfNoTests"
     },
     "build": {
         "enabled": true,

--- a/backend/trade-service/Dockerfile
+++ b/backend/trade-service/Dockerfile
@@ -25,7 +25,7 @@ WORKDIR /build
 COPY ./src src/
 RUN --mount=type=bind,source=pom.xml,target=pom.xml \
     --mount=type=cache,target=/root/.m2 \
-    ./mvnw package -DskipTests && \
+    ./mvnw package -DskipTests -Djacoco.skip && \
     cp target/*.jar target/app.jar
 
 FROM eclipse-temurin:25-jre-alpine AS final

--- a/backend/user-service/.ci.json
+++ b/backend/user-service/.ci.json
@@ -6,7 +6,7 @@
     },
     "test": {
         "enabled": true,
-        "command": "mvn -B test"
+        "command": "mvn -B test -DfailIfNoTests"
     },
     "build": {
         "enabled": true,

--- a/backend/user-service/Dockerfile
+++ b/backend/user-service/Dockerfile
@@ -25,7 +25,7 @@ WORKDIR /build
 COPY ./src src/
 RUN --mount=type=bind,source=pom.xml,target=pom.xml \
     --mount=type=cache,target=/root/.m2 \
-    ./mvnw package -DskipTests && \
+    ./mvnw package -DskipTests -Djacoco.skip && \
     cp target/*.jar target/app.jar
 
 FROM eclipse-temurin:25-jre-alpine AS final


### PR DESCRIPTION
- Added the `-DfailIfNoTests` flag to maven tests to make it more clear that tests are missing for a service
- Also added missing `-Djacoco.skip` flags to packge commands in Dockerfiles to prevent possible failures from low coverage
